### PR TITLE
Disputed stakes

### DIFF
--- a/contracts/oldContracts/contracts/interfaces/ITellor.sol
+++ b/contracts/oldContracts/contracts/interfaces/ITellor.sol
@@ -41,7 +41,8 @@ interface ITellor{
     function balanceOf(address _user) external view returns (uint256);
     function balanceOfAt(address _user, uint256 _blockNumber)external view returns (uint256);
     function transfer(address _to, uint256 _amount)external returns (bool success);
-    function transferFrom(address _from,address _to,uint256 _amount) external returns (bool success) ;
+    function transferFrom(address _from,address _to,uint256 _amount) external returns (bool success);
+    function teamTransferDisputedStake(address _from, address _to) external returns (bool success);
     function depositStake() external;
     function requestStakingWithdraw() external;
     function withdrawStake() external;

--- a/contracts/tellor360.sol
+++ b/contracts/tellor360.sol
@@ -98,7 +98,6 @@ contract Tellor360 is BaseToken, NewTransition {
         _doMint(addresses[_OWNER], _releasedAmount);
     }
 
-    //TODO: be sure to test we can't just print tokens
     /**
      * @dev This function allows team to gain control of any tokens sent directly to this
      * contract (and send them back))


### PR DESCRIPTION
- ensures disputed reporters can't just transfer stake after 360 init
- allows team to transfer disputed stakes after init